### PR TITLE
React Native SDK: add native CardField + CardCapture

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,44 @@ In your React Native project, import the components and hooks as named exports:
 import { SafepayPayerAuthentication, SafepayContext, EnrollmentAuthenticationStatus, Cardinal3dsSuccessData, Cardinal3dsFailureData, AuthorizationResponse, PayerAuthEnrollmentFailureError } from "@sfpy/react-native";
 ```
 
+## Native Card Capture (embedded)
+
+This package now exposes an embedded native card input via `CardField` and a lightweight `CardCapture` wrapper.
+
+### iOS setup
+
+Make sure `SafepayiOSSDK` is available to CocoaPods (local path or published pod). Example Podfile entry:
+
+```
+pod 'SafepayiOSSDK', :path => '../safepay-ios-sdk'
+```
+
+### Android setup
+
+The Android SDK module must be included in your app Gradle settings as `:safePay`, then depended on by this library.
+If using the repo as a git submodule, include:
+
+```
+include(":safePay")
+project(":safePay").projectDir = new File(rootProject.projectDir, "../safepay-android-sdk/safePay")
+```
+
+### Example usage
+
+```tsx
+import { CardField } from "@sfpy/react-native";
+
+export function PaymentForm() {
+  return (
+    <CardField
+      onCardChange={(card) => console.log("card", card)}
+      dangerouslyGetFullCardDetails={false}
+      style={{ height: 120 }}
+    />
+  );
+}
+```
+
 ## Example usage
 
 Use the SafepayPayerAuthentication in the following way using the SafepayContext.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,12 +17,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+    id "com.android.library"
+    id "org.jetbrains.kotlin.android"
+}
+
+android {
+    namespace "com.sfpy.reactnative"
+    compileSdkVersion 34
+
+    defaultConfig {
+        minSdkVersion 24
+        targetSdkVersion 34
+    }
+
+    buildFeatures {
+        buildConfig true
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
+dependencies {
+    implementation "com.facebook.react:react-native:+"
+    implementation project(":safePay")
+}

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.sfpy.reactnative" />

--- a/android/src/main/java/com/sfpy/reactnative/SFPYCardCaptureView.kt
+++ b/android/src/main/java/com/sfpy/reactnative/SFPYCardCaptureView.kt
@@ -1,0 +1,154 @@
+package com.sfpy.reactnative
+
+import android.widget.FrameLayout
+import com.android.safepay.network.error.PaymentError
+import com.android.safepay.network.ui.card.SafepayCardCaptureConfiguration
+import com.android.safepay.network.ui.card.SafepayCardCaptureController
+import com.android.safepay.network.ui.card.SafepayCardCaptureEnvironment
+import com.android.safepay.network.ui.card.SafepayCardCaptureResult
+import com.android.safepay.network.ui.card.SafepayCardFieldView
+import com.facebook.react.uimanager.ThemedReactContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class SFPYCardCaptureView(
+    private val reactContext: ThemedReactContext,
+) : FrameLayout(reactContext) {
+    interface Listener {
+        fun onReady()
+        fun onCardChange(details: SafepayCardFieldView.CardFieldDetails)
+        fun onValidated()
+        fun onError(code: String?, message: String)
+        fun onProceedToAuthentication(result: SafepayCardCaptureResult)
+    }
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val cardFieldView = SafepayCardFieldView(reactContext)
+
+    private var listener: Listener? = null
+    private var controller: SafepayCardCaptureController? = null
+    private var environment: String? = null
+    private var authToken: String? = null
+    private var tracker: String? = null
+    private var lastConfigurationKey: String? = null
+    private var didEmitReady = false
+
+    init {
+        addView(
+            cardFieldView,
+            LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT),
+        )
+
+        cardFieldView.setOnCardChangeListener(
+            object : SafepayCardFieldView.OnCardChangeListener {
+                override fun onCardChange(details: SafepayCardFieldView.CardFieldDetails) {
+                    listener?.onCardChange(details)
+                }
+            },
+        )
+    }
+
+    fun setListener(listener: Listener?) {
+        this.listener = listener
+    }
+
+    fun setEnvironment(value: String?) {
+        environment = value
+        configureControllerIfPossible()
+    }
+
+    fun setAuthToken(value: String?) {
+        authToken = value
+        configureControllerIfPossible()
+    }
+
+    fun setTracker(value: String?) {
+        tracker = value
+        configureControllerIfPossible()
+    }
+
+    fun setDisabled(disabled: Boolean) {
+        cardFieldView.setDisabled(disabled)
+    }
+
+    fun setAutofocus(autofocus: Boolean) {
+        if (autofocus) {
+            cardFieldView.focus()
+        }
+    }
+
+    fun submit() {
+        val controller = controller
+        if (controller == null) {
+            listener?.onError(null, "CardCapture is missing required configuration.")
+            return
+        }
+
+        scope.launch {
+            try {
+                val result =
+                    withContext(Dispatchers.IO) {
+                        controller.submit()
+                    }
+                listener?.onValidated()
+                listener?.onProceedToAuthentication(result)
+            } catch (error: PaymentError) {
+                listener?.onError(error.code, error.msg)
+            } catch (error: Exception) {
+                listener?.onError(null, error.localizedMessage ?: "Unknown error")
+            }
+        }
+    }
+
+    fun clear() {
+        controller?.clear() ?: cardFieldView.clear()
+    }
+
+    override fun onDetachedFromWindow() {
+        scope.cancel()
+        super.onDetachedFromWindow()
+    }
+
+    private fun configureControllerIfPossible() {
+        val resolvedEnvironment =
+            environment
+                ?.trim()
+                ?.lowercase()
+                ?.let {
+                    when (it) {
+                        "development" -> SafepayCardCaptureEnvironment.DEVELOPMENT
+                        "sandbox" -> SafepayCardCaptureEnvironment.SANDBOX
+                        "production" -> SafepayCardCaptureEnvironment.PRODUCTION
+                        else -> null
+                    }
+                } ?: return
+        val resolvedAuthToken = authToken?.takeIf { it.isNotBlank() } ?: return
+        val resolvedTracker = tracker?.takeIf { it.isNotBlank() } ?: return
+
+        val configurationKey = "${resolvedEnvironment.name}|$resolvedAuthToken|$resolvedTracker"
+        if (configurationKey == lastConfigurationKey) {
+            return
+        }
+
+        controller =
+            SafepayCardCaptureController(
+                configuration =
+                    SafepayCardCaptureConfiguration(
+                        environment = resolvedEnvironment,
+                        authToken = resolvedAuthToken,
+                        tracker = resolvedTracker,
+                    ),
+                cardFieldView = cardFieldView,
+            )
+        lastConfigurationKey = configurationKey
+
+        if (!didEmitReady) {
+            didEmitReady = true
+            listener?.onReady()
+        }
+    }
+}

--- a/android/src/main/java/com/sfpy/reactnative/SFPYCardCaptureViewManager.kt
+++ b/android/src/main/java/com/sfpy/reactnative/SFPYCardCaptureViewManager.kt
@@ -1,0 +1,171 @@
+package com.sfpy.reactnative
+
+import com.android.safepay.network.ui.card.SafepayCardCaptureResult
+import com.android.safepay.network.ui.card.SafepayCardFieldView
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReactContext
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.SimpleViewManager
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.annotations.ReactProp
+import com.facebook.react.uimanager.events.RCTEventEmitter
+
+class SFPYCardCaptureViewManager : SimpleViewManager<SFPYCardCaptureView>() {
+    override fun getName(): String = REACT_CLASS
+
+    override fun createViewInstance(reactContext: ThemedReactContext): SFPYCardCaptureView {
+        val view = SFPYCardCaptureView(reactContext)
+
+        view.setListener(
+            object : SFPYCardCaptureView.Listener {
+                override fun onReady() {
+                    reactContext
+                        .getJSModule(RCTEventEmitter::class.java)
+                        .receiveEvent(view.id, EVENT_READY, Arguments.createMap())
+                }
+
+                override fun onCardChange(details: SafepayCardFieldView.CardFieldDetails) {
+                    reactContext
+                        .getJSModule(RCTEventEmitter::class.java)
+                        .receiveEvent(view.id, EVENT_CARD_CHANGE, createCardChangeEvent(details))
+                }
+
+                override fun onValidated() {
+                    reactContext
+                        .getJSModule(RCTEventEmitter::class.java)
+                        .receiveEvent(view.id, EVENT_VALIDATED, Arguments.createMap())
+                }
+
+                override fun onError(code: String?, message: String) {
+                    val event =
+                        Arguments.createMap().apply {
+                            putMap(
+                                "error",
+                                Arguments.createMap().apply {
+                                    code?.let { putString("code", it) } ?: putNull("code")
+                                    putString("message", message)
+                                },
+                            )
+                        }
+                    reactContext
+                        .getJSModule(RCTEventEmitter::class.java)
+                        .receiveEvent(view.id, EVENT_ERROR, event)
+                }
+
+                override fun onProceedToAuthentication(result: SafepayCardCaptureResult) {
+                    val event =
+                        Arguments.createMap().apply {
+                            putMap(
+                                "result",
+                                Arguments.createMap().apply {
+                                    putString("accessToken", result.accessToken)
+                                    putString("deviceDataCollectionURL", result.deviceDataCollectionURL)
+                                    result.cardinalJWT?.let { putString("cardinalJWT", it) } ?: putNull("cardinalJWT")
+                                    putMap(
+                                        "paymentMethod",
+                                        Arguments.createMap().apply {
+                                            putString("token", result.paymentMethod.token)
+                                            putString("expirationMonth", result.paymentMethod.expirationMonth)
+                                            putString("expirationYear", result.paymentMethod.expirationYear)
+                                            putString("cardTypeCode", result.paymentMethod.cardTypeCode)
+                                            putString("cardType", result.paymentMethod.cardType)
+                                            putString("binNumber", result.paymentMethod.binNumber)
+                                            putString("lastFour", result.paymentMethod.lastFour)
+                                        },
+                                    )
+                                },
+                            )
+                        }
+                    reactContext
+                        .getJSModule(RCTEventEmitter::class.java)
+                        .receiveEvent(view.id, EVENT_PROCEED_TO_AUTHENTICATION, event)
+                }
+            },
+        )
+
+        return view
+    }
+
+    @ReactProp(name = "environment")
+    fun setEnvironment(view: SFPYCardCaptureView, value: String?) {
+        view.setEnvironment(value)
+    }
+
+    @ReactProp(name = "authToken")
+    fun setAuthToken(view: SFPYCardCaptureView, value: String?) {
+        view.setAuthToken(value)
+    }
+
+    @ReactProp(name = "tracker")
+    fun setTracker(view: SFPYCardCaptureView, value: String?) {
+        view.setTracker(value)
+    }
+
+    @ReactProp(name = "disabled")
+    fun setDisabled(view: SFPYCardCaptureView, disabled: Boolean) {
+        view.setDisabled(disabled)
+    }
+
+    @ReactProp(name = "autofocus")
+    fun setAutofocus(view: SFPYCardCaptureView, autofocus: Boolean) {
+        view.setAutofocus(autofocus)
+    }
+
+    override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
+        return mutableMapOf(
+            EVENT_READY to mapOf("registrationName" to "onReady"),
+            EVENT_CARD_CHANGE to mapOf("registrationName" to "onCardChange"),
+            EVENT_VALIDATED to mapOf("registrationName" to "onValidated"),
+            EVENT_ERROR to mapOf("registrationName" to "onError"),
+            EVENT_PROCEED_TO_AUTHENTICATION to
+                mapOf("registrationName" to "onProceedToAuthentication"),
+        )
+    }
+
+    override fun getCommandsMap(): MutableMap<String, Int> {
+        return mutableMapOf(
+            "submit" to COMMAND_SUBMIT,
+            "clear" to COMMAND_CLEAR,
+        )
+    }
+
+    override fun receiveCommand(
+        root: SFPYCardCaptureView,
+        commandId: Int,
+        args: com.facebook.react.bridge.ReadableArray?,
+    ) {
+        when (commandId) {
+            COMMAND_SUBMIT -> root.submit()
+            COMMAND_CLEAR -> root.clear()
+        }
+    }
+
+    private fun createCardChangeEvent(details: SafepayCardFieldView.CardFieldDetails): WritableMap {
+        val card =
+            Arguments.createMap().apply {
+                putString("brand", details.brand)
+                putString("last4", details.last4)
+                details.expiryMonth?.let { putInt("expiryMonth", it) } ?: putNull("expiryMonth")
+                details.expiryYear?.let { putInt("expiryYear", it) } ?: putNull("expiryYear")
+                putBoolean("complete", details.complete)
+                putString("validNumber", details.validNumber)
+                putString("validCVC", details.validCvc)
+                putString("validExpiryDate", details.validExpiryDate)
+            }
+
+        return Arguments.createMap().apply {
+            putMap("card", card)
+        }
+    }
+
+    companion object {
+        const val REACT_CLASS = "SFPYCardCapture"
+        private const val EVENT_READY = "topReady"
+        private const val EVENT_CARD_CHANGE = "topCardChange"
+        private const val EVENT_VALIDATED = "topValidated"
+        private const val EVENT_ERROR = "topError"
+        private const val EVENT_PROCEED_TO_AUTHENTICATION = "topProceedToAuthentication"
+        private const val COMMAND_SUBMIT = 1
+        private const val COMMAND_CLEAR = 2
+    }
+}

--- a/android/src/main/java/com/sfpy/reactnative/SFPYCardFieldViewManager.kt
+++ b/android/src/main/java/com/sfpy/reactnative/SFPYCardFieldViewManager.kt
@@ -15,21 +15,29 @@ class SFPYCardFieldViewManager : SimpleViewManager<SafepayCardFieldView>() {
     override fun createViewInstance(reactContext: ThemedReactContext): SafepayCardFieldView {
         val view = SafepayCardFieldView(reactContext)
 
-        view.setOnCardChangeListener { details ->
-            val event = createCardChangeEvent(details)
-            reactContext
-                .getJSModule(RCTEventEmitter::class.java)
-                .receiveEvent(view.id, EVENT_CARD_CHANGE, event)
-        }
+        view.setOnCardChangeListener(
+            object : SafepayCardFieldView.OnCardChangeListener {
+                override fun onCardChange(details: SafepayCardFieldView.CardFieldDetails) {
+                    val event = createCardChangeEvent(details)
+                    reactContext
+                        .getJSModule(RCTEventEmitter::class.java)
+                        .receiveEvent(view.id, EVENT_CARD_CHANGE, event)
+                }
+            },
+        )
 
-        view.setOnFocusChangeListener { focus ->
-            val event = Arguments.createMap().apply {
-                putString("focusedField", focus?.name ?: "")
-            }
-            reactContext
-                .getJSModule(RCTEventEmitter::class.java)
-                .receiveEvent(view.id, EVENT_FOCUS_CHANGE, event)
-        }
+        view.setOnFocusChangeListener(
+            object : SafepayCardFieldView.OnFocusChangeListener {
+                override fun onFocusChange(focusedField: SafepayCardFieldView.FocusField?) {
+                    val event = Arguments.createMap().apply {
+                        putString("focusedField", focusedField?.name ?: "")
+                    }
+                    reactContext
+                        .getJSModule(RCTEventEmitter::class.java)
+                        .receiveEvent(view.id, EVENT_FOCUS_CHANGE, event)
+                }
+            },
+        )
 
         return view
     }

--- a/android/src/main/java/com/sfpy/reactnative/SFPYCardFieldViewManager.kt
+++ b/android/src/main/java/com/sfpy/reactnative/SFPYCardFieldViewManager.kt
@@ -1,0 +1,108 @@
+package com.sfpy.reactnative
+
+import com.android.safepay.network.ui.card.SafepayCardFieldView
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReactContext
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.SimpleViewManager
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.annotations.ReactProp
+import com.facebook.react.uimanager.events.RCTEventEmitter
+
+class SFPYCardFieldViewManager : SimpleViewManager<SafepayCardFieldView>() {
+    override fun getName(): String = REACT_CLASS
+
+    override fun createViewInstance(reactContext: ThemedReactContext): SafepayCardFieldView {
+        val view = SafepayCardFieldView(reactContext)
+
+        view.setOnCardChangeListener { details ->
+            val event = createCardChangeEvent(details)
+            reactContext
+                .getJSModule(RCTEventEmitter::class.java)
+                .receiveEvent(view.id, EVENT_CARD_CHANGE, event)
+        }
+
+        view.setOnFocusChangeListener { focus ->
+            val event = Arguments.createMap().apply {
+                putString("focusedField", focus?.name ?: "")
+            }
+            reactContext
+                .getJSModule(RCTEventEmitter::class.java)
+                .receiveEvent(view.id, EVENT_FOCUS_CHANGE, event)
+        }
+
+        return view
+    }
+
+    @ReactProp(name = "dangerouslyGetFullCardDetails")
+    fun setDangerouslyGetFullCardDetails(view: SafepayCardFieldView, value: Boolean) {
+        view.dangerouslyGetFullCardDetails = value
+    }
+
+    @ReactProp(name = "disabled")
+    fun setDisabled(view: SafepayCardFieldView, disabled: Boolean) {
+        view.setDisabled(disabled)
+    }
+
+    @ReactProp(name = "autofocus")
+    fun setAutofocus(view: SafepayCardFieldView, autofocus: Boolean) {
+        if (autofocus) {
+            view.focus()
+        }
+    }
+
+    override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
+        return mutableMapOf(
+            EVENT_CARD_CHANGE to mapOf("registrationName" to "onCardChange"),
+            EVENT_FOCUS_CHANGE to mapOf("registrationName" to "onFocusChange"),
+        )
+    }
+
+    override fun getCommandsMap(): MutableMap<String, Int> {
+        return mutableMapOf(
+            "focus" to COMMAND_FOCUS,
+            "blur" to COMMAND_BLUR,
+            "clear" to COMMAND_CLEAR,
+        )
+    }
+
+    override fun receiveCommand(
+        root: SafepayCardFieldView,
+        commandId: Int,
+        args: com.facebook.react.bridge.ReadableArray?,
+    ) {
+        when (commandId) {
+            COMMAND_FOCUS -> root.focus()
+            COMMAND_BLUR -> root.blur()
+            COMMAND_CLEAR -> root.clear()
+        }
+    }
+
+    private fun createCardChangeEvent(details: SafepayCardFieldView.CardFieldDetails): WritableMap {
+        val card = Arguments.createMap().apply {
+            putString("brand", details.brand)
+            putString("last4", details.last4)
+            details.expiryMonth?.let { putInt("expiryMonth", it) } ?: putNull("expiryMonth")
+            details.expiryYear?.let { putInt("expiryYear", it) } ?: putNull("expiryYear")
+            putBoolean("complete", details.complete)
+            putString("validNumber", details.validNumber)
+            putString("validCVC", details.validCvc)
+            putString("validExpiryDate", details.validExpiryDate)
+            details.number?.let { putString("number", it) }
+            details.cvc?.let { putString("cvc", it) }
+        }
+
+        return Arguments.createMap().apply {
+            putMap("card", card)
+        }
+    }
+
+    companion object {
+        const val REACT_CLASS = "SFPYCardField"
+        private const val EVENT_CARD_CHANGE = "topCardChange"
+        private const val EVENT_FOCUS_CHANGE = "topFocusChange"
+        private const val COMMAND_FOCUS = 1
+        private const val COMMAND_BLUR = 2
+        private const val COMMAND_CLEAR = 3
+    }
+}

--- a/android/src/main/java/com/sfpy/reactnative/SfpyReactNativePackage.kt
+++ b/android/src/main/java/com/sfpy/reactnative/SfpyReactNativePackage.kt
@@ -1,0 +1,18 @@
+package com.sfpy.reactnative
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class SfpyReactNativePackage : ReactPackage {
+    override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
+        return emptyList()
+    }
+
+    override fun createViewManagers(
+        reactContext: ReactApplicationContext,
+    ): List<ViewManager<*, *>> {
+        return listOf(SFPYCardFieldViewManager())
+    }
+}

--- a/android/src/main/java/com/sfpy/reactnative/SfpyReactNativePackage.kt
+++ b/android/src/main/java/com/sfpy/reactnative/SfpyReactNativePackage.kt
@@ -13,6 +13,9 @@ class SfpyReactNativePackage : ReactPackage {
     override fun createViewManagers(
         reactContext: ReactApplicationContext,
     ): List<ViewManager<*, *>> {
-        return listOf(SFPYCardFieldViewManager())
+        return listOf(
+            SFPYCardFieldViewManager(),
+            SFPYCardCaptureViewManager(),
+        )
     }
 }

--- a/docs/actions/01-card-capture-public-contract.md
+++ b/docs/actions/01-card-capture-public-contract.md
@@ -1,0 +1,25 @@
+# 01 Card Capture Public Contract
+
+Status: implemented for the first native-backed pass.
+
+## What changed
+Replaced the JS-only `CardCapture` stub with a native-backed React Native component that mirrors the Atoms contract closely enough for the card-capture phase.
+
+The RN component now:
+- renders a dedicated native `SFPYCardCapture` view on iOS and Android
+- keeps local validity state in JS using non-sensitive card-change events
+- delegates `submit()` to native so `PAYER_AUTH_SETUP` happens inside the native SDKs
+- returns `accessToken`, `deviceDataCollectionURL`, `paymentMethod`, and `cardinalJWT` through `onProceedToAuthentication`
+
+## Public JS surface
+The RN surface now exposes:
+- props: `environment`, `authToken`, `tracker`, `validationEvent`, `onReady`, `onValidated`, `onError`, `onProceedToAuthentication`, `imperativeRef`
+- imperative methods: `submit()`, `validate()`, `fetchValidity()`, `clear()`
+
+`validate()` and `fetchValidity()` still use the sanitized card validity state already emitted by the native view. `submit()` is the only path that crosses into native orchestration.
+
+## Security constraint
+Full PAN/CVV no longer drive backend calls from JS. The JS layer only sees sanitized card state plus the downstream payer-auth setup payload.
+
+## Still out of scope
+This work still stops at `CardCapture`. DDC, challenge handling, and post-auth authorization remain downstream in `SafepayPayerAuthentication`.

--- a/docs/actions/02-native-bridge-orchestration.md
+++ b/docs/actions/02-native-bridge-orchestration.md
@@ -1,0 +1,34 @@
+# 02 Native Bridge Orchestration
+
+Status: implemented for the legacy RN bridge; Fabric/new-architecture support still remains.
+
+## What changed
+Added a dedicated native `SFPYCardCapture` bridge on both platforms.
+
+On iOS:
+- added `ios/SFPYCardCaptureView.swift`
+- added `ios/SFPYCardCaptureManager.swift`
+- added `ios/SFPYCardCaptureManager.m`
+
+On Android:
+- added `android/src/main/java/com/sfpy/reactnative/SFPYCardCaptureView.kt`
+- added `android/src/main/java/com/sfpy/reactnative/SFPYCardCaptureViewManager.kt`
+- registered the new manager in `SfpyReactNativePackage.kt`
+
+## Native responsibilities now covered
+The native bridge now:
+- hosts the reusable native card input
+- creates the native SDK card-capture controller once `environment`, `authToken`, and `tracker` are available
+- owns `submit()` and the `PAYER_AUTH_SETUP` network call
+- emits `onReady`, `onValidated`, `onError`, and `onProceedToAuthentication`
+- keeps raw card submission data native-side
+
+## JS responsibilities now covered
+The JS `CardCapture` component now:
+- wraps the native `SFPYCardCapture` view instead of nesting `CardField`
+- keeps sanitized validity state for `validate()` and `fetchValidity()`
+- dispatches native `submit` and `clear` commands
+- normalizes native event payloads into the public JS callbacks
+
+## Remaining gap
+This bridge is still legacy-view-manager based. The Fabric/new-architecture requirement is not satisfied yet, so bridgeless/Fabric support remains a follow-up rather than something completed in this pass.

--- a/docs/actions/02-native-bridge-orchestration.md
+++ b/docs/actions/02-native-bridge-orchestration.md
@@ -22,6 +22,7 @@ The native bridge now:
 - owns `submit()` and the `PAYER_AUTH_SETUP` network call
 - emits `onReady`, `onValidated`, `onError`, and `onProceedToAuthentication`
 - keeps raw card submission data native-side
+- normalizes optional Swift payload fields into React Native dictionaries before emitting them
 
 ## JS responsibilities now covered
 The JS `CardCapture` component now:

--- a/docs/actions/03-rollout-testing.md
+++ b/docs/actions/03-rollout-testing.md
@@ -1,0 +1,24 @@
+# 03 Rollout And Testing
+
+Status: partially verified.
+
+## What was verified
+- TypeScript build passed with `npm run build`
+- native SDK controller work was already compiled on Android in the SDK repo
+- the RN `CardCapture` public surface now returns proceed-to-auth payloads without JS reading PAN/CVV
+
+## What still needs verification
+### Functional
+- incomplete card surfaces native validation errors correctly on both platforms
+- payer-auth setup API failures map cleanly into `onError`
+- success path returns `onProceedToAuthentication` on both platforms
+
+### Platform
+- iOS example app rebuild against the new native bridge
+- Android example app rebuild against the new native bridge
+- legacy architecture runtime smoke test
+- Fabric/new-architecture runtime test after a Fabric bridge exists
+
+## Known remaining gaps
+- tracker reset parity with drops is still not implemented in the native SDKs
+- the RN bridge is still legacy-only and does not yet satisfy the Fabric requirement

--- a/ios/SFPYCardCaptureManager.m
+++ b/ios/SFPYCardCaptureManager.m
@@ -1,0 +1,18 @@
+#import <Foundation/Foundation.h>
+#import <React/RCTBridgeModule.h>
+#import <React/RCTViewManager.h>
+
+@interface RCT_EXTERN_MODULE(SFPYCardCapture, RCTViewManager)
+RCT_EXPORT_VIEW_PROPERTY(onReady, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onCardChange, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onValidated, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onError, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onProceedToAuthentication, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(environment, NSString)
+RCT_EXPORT_VIEW_PROPERTY(authToken, NSString)
+RCT_EXPORT_VIEW_PROPERTY(tracker, NSString)
+RCT_EXPORT_VIEW_PROPERTY(disabled, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(autofocus, BOOL)
+RCT_EXTERN_METHOD(submit:(nonnull NSNumber*) reactTag)
+RCT_EXTERN_METHOD(clear:(nonnull NSNumber*) reactTag)
+@end

--- a/ios/SFPYCardCaptureManager.swift
+++ b/ios/SFPYCardCaptureManager.swift
@@ -1,0 +1,29 @@
+import Foundation
+import React
+
+@objc(SFPYCardCapture)
+class SFPYCardCaptureManager: RCTViewManager {
+    override func view() -> UIView! {
+        return SFPYCardCaptureView()
+    }
+
+    @objc func submit(_ reactTag: NSNumber) {
+        bridge?.uiManager.addUIBlock { _, viewRegistry in
+            if let view = viewRegistry?[reactTag] as? SFPYCardCaptureView {
+                view.submit()
+            }
+        }
+    }
+
+    @objc func clear(_ reactTag: NSNumber) {
+        bridge?.uiManager.addUIBlock { _, viewRegistry in
+            if let view = viewRegistry?[reactTag] as? SFPYCardCaptureView {
+                view.clear()
+            }
+        }
+    }
+
+    override static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
+}

--- a/ios/SFPYCardCaptureView.swift
+++ b/ios/SFPYCardCaptureView.swift
@@ -171,30 +171,30 @@ class SFPYCardCaptureView: UIView {
     }
 
     private func emitError(code: String?, message: String) {
-        onError?([
-            "error": [
-                "code": code ?? NSNull(),
-                "message": message,
-            ]
-        ])
+        let errorPayload: [String: Any] = [
+            "code": code ?? NSNull(),
+            "message": message,
+        ]
+
+        onError?(["error": errorPayload])
     }
 
     private func emitProceed(_ result: SafepayCardCaptureResult) {
-        onProceedToAuthentication?([
-            "result": [
-                "accessToken": result.accessToken,
-                "deviceDataCollectionURL": result.deviceDataCollectionURL,
-                "cardinalJWT": result.cardinalJWT ?? NSNull(),
-                "paymentMethod": [
-                    "token": result.paymentMethod.token,
-                    "expirationMonth": result.paymentMethod.expirationMonth,
-                    "expirationYear": result.paymentMethod.expirationYear,
-                    "cardTypeCode": result.paymentMethod.cardTypeCode,
-                    "cardType": result.paymentMethod.cardType,
-                    "binNumber": result.paymentMethod.binNumber,
-                    "lastFour": result.paymentMethod.lastFour,
-                ],
-            ]
-        ])
+        let resultPayload: [String: Any] = [
+            "accessToken": result.accessToken,
+            "deviceDataCollectionURL": result.deviceDataCollectionURL,
+            "cardinalJWT": result.cardinalJWT ?? NSNull(),
+            "paymentMethod": [
+                "token": result.paymentMethod.token,
+                "expirationMonth": result.paymentMethod.expirationMonth,
+                "expirationYear": result.paymentMethod.expirationYear,
+                "cardTypeCode": result.paymentMethod.cardTypeCode,
+                "cardType": result.paymentMethod.cardType,
+                "binNumber": result.paymentMethod.binNumber,
+                "lastFour": result.paymentMethod.lastFour,
+            ],
+        ]
+
+        onProceedToAuthentication?(["result": resultPayload])
     }
 }

--- a/ios/SFPYCardCaptureView.swift
+++ b/ios/SFPYCardCaptureView.swift
@@ -1,0 +1,200 @@
+import Foundation
+import React
+import SafepayiOSSDK
+import UIKit
+
+@objc(SFPYCardCaptureView)
+class SFPYCardCaptureView: UIView {
+    @objc var onReady: RCTDirectEventBlock?
+    @objc var onCardChange: RCTDirectEventBlock?
+    @objc var onValidated: RCTDirectEventBlock?
+    @objc var onError: RCTDirectEventBlock?
+    @objc var onProceedToAuthentication: RCTDirectEventBlock?
+
+    @objc var environment: NSString? {
+        didSet {
+            configureControllerIfPossible()
+        }
+    }
+
+    @objc var authToken: NSString? {
+        didSet {
+            configureControllerIfPossible()
+        }
+    }
+
+    @objc var tracker: NSString? {
+        didSet {
+            configureControllerIfPossible()
+        }
+    }
+
+    @objc var disabled: Bool = false {
+        didSet {
+            cardFieldView.isUserInteractionEnabled = !disabled
+        }
+    }
+
+    @objc var autofocus: Bool = false {
+        didSet {
+            if autofocus {
+                cardFieldView.focus()
+            }
+        }
+    }
+
+    private let cardFieldView = SafepayCardFieldView()
+    private var controller: SafepayCardCaptureController?
+    private var lastConfigurationKey: String?
+    private var didEmitReady = false
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupView()
+    }
+
+    @objc func submit() {
+        guard let controller = controller else {
+            emitError(code: nil, message: "CardCapture is missing required configuration.")
+            return
+        }
+
+        Task { [weak self] in
+            do {
+                let result = try await controller.submit()
+                await MainActor.run {
+                    self?.onValidated?([:])
+                    self?.emitProceed(result)
+                }
+            } catch let error as PaymentError {
+                await MainActor.run {
+                    self?.emitError(code: error.code, message: error.message)
+                }
+            } catch let error as ErrorResponse {
+                await MainActor.run {
+                    self?.emitError(code: error.code, message: error.errorMessage)
+                }
+            } catch {
+                await MainActor.run {
+                    self?.emitError(code: nil, message: error.localizedDescription)
+                }
+            }
+        }
+    }
+
+    @objc func clear() {
+        controller?.clear() ?? cardFieldView.clear()
+    }
+
+    private func setupView() {
+        cardFieldView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(cardFieldView)
+
+        NSLayoutConstraint.activate([
+            cardFieldView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            cardFieldView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            cardFieldView.topAnchor.constraint(equalTo: topAnchor),
+            cardFieldView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+
+        cardFieldView.cardChangeHandler = { [weak self] details in
+            self?.emitCardChange(details)
+        }
+    }
+
+    private func configureControllerIfPossible() {
+        guard
+            let environmentValue = environment as String?,
+            let environment = parseEnvironment(environmentValue),
+            let authTokenValue = authToken as String?,
+            !authTokenValue.isEmpty,
+            let trackerValue = tracker as String?,
+            !trackerValue.isEmpty
+        else {
+            return
+        }
+
+        let configurationKey = "\(environment.rawValue)|\(authTokenValue)|\(trackerValue)"
+        guard configurationKey != lastConfigurationKey else {
+            return
+        }
+
+        controller = SafepayCardCaptureController(
+            configuration: SafepayCardCaptureConfiguration(
+                environment: environment,
+                authToken: authTokenValue,
+                tracker: trackerValue
+            ),
+            cardFieldView: cardFieldView
+        )
+        lastConfigurationKey = configurationKey
+
+        if !didEmitReady {
+            didEmitReady = true
+            onReady?([:])
+        }
+    }
+
+    private func parseEnvironment(_ value: String) -> SafepayCardCaptureEnvironment? {
+        SafepayCardCaptureEnvironment(rawValue: value.lowercased())
+    }
+
+    private func emitCardChange(_ details: SafepayCardFieldDetails) {
+        var card: [String: Any] = [
+            "complete": details.complete,
+            "validNumber": details.validNumber,
+            "validCVC": details.validCVC,
+            "validExpiryDate": details.validExpiryDate,
+        ]
+
+        card["brand"] = details.brand ?? NSNull()
+        card["last4"] = details.last4 ?? ""
+
+        if let expiryMonth = details.expiryMonth {
+            card["expiryMonth"] = expiryMonth
+        } else {
+            card["expiryMonth"] = NSNull()
+        }
+
+        if let expiryYear = details.expiryYear {
+            card["expiryYear"] = expiryYear
+        } else {
+            card["expiryYear"] = NSNull()
+        }
+
+        onCardChange?(["card": card])
+    }
+
+    private func emitError(code: String?, message: String) {
+        onError?([
+            "error": [
+                "code": code ?? NSNull(),
+                "message": message,
+            ]
+        ])
+    }
+
+    private func emitProceed(_ result: SafepayCardCaptureResult) {
+        onProceedToAuthentication?([
+            "result": [
+                "accessToken": result.accessToken,
+                "deviceDataCollectionURL": result.deviceDataCollectionURL,
+                "cardinalJWT": result.cardinalJWT ?? NSNull(),
+                "paymentMethod": [
+                    "token": result.paymentMethod.token,
+                    "expirationMonth": result.paymentMethod.expirationMonth,
+                    "expirationYear": result.paymentMethod.expirationYear,
+                    "cardTypeCode": result.paymentMethod.cardTypeCode,
+                    "cardType": result.paymentMethod.cardType,
+                    "binNumber": result.paymentMethod.binNumber,
+                    "lastFour": result.paymentMethod.lastFour,
+                ],
+            ]
+        ])
+    }
+}

--- a/ios/SFPYCardFieldManager.m
+++ b/ios/SFPYCardFieldManager.m
@@ -1,0 +1,14 @@
+#import <Foundation/Foundation.h>
+#import <React/RCTBridgeModule.h>
+#import <React/RCTViewManager.h>
+
+@interface RCT_EXTERN_MODULE(SFPYCardField, RCTViewManager)
+RCT_EXPORT_VIEW_PROPERTY(onCardChange, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onFocusChange, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(dangerouslyGetFullCardDetails, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(disabled, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(autofocus, BOOL)
+RCT_EXTERN_METHOD(focus:(nonnull NSNumber*) reactTag)
+RCT_EXTERN_METHOD(blur:(nonnull NSNumber*) reactTag)
+RCT_EXTERN_METHOD(clear:(nonnull NSNumber*) reactTag)
+@end

--- a/ios/SFPYCardFieldManager.swift
+++ b/ios/SFPYCardFieldManager.swift
@@ -1,0 +1,37 @@
+import Foundation
+import React
+
+@objc(SFPYCardField)
+class SFPYCardFieldManager: RCTViewManager {
+    override func view() -> UIView! {
+        return SFPYCardFieldView()
+    }
+
+    @objc func focus(_ reactTag: NSNumber) {
+        bridge?.uiManager.addUIBlock { _, viewRegistry in
+            if let view = viewRegistry?[reactTag] as? SFPYCardFieldView {
+                view.focus()
+            }
+        }
+    }
+
+    @objc func blur(_ reactTag: NSNumber) {
+        bridge?.uiManager.addUIBlock { _, viewRegistry in
+            if let view = viewRegistry?[reactTag] as? SFPYCardFieldView {
+                view.blur()
+            }
+        }
+    }
+
+    @objc func clear(_ reactTag: NSNumber) {
+        bridge?.uiManager.addUIBlock { _, viewRegistry in
+            if let view = viewRegistry?[reactTag] as? SFPYCardFieldView {
+                view.clear()
+            }
+        }
+    }
+
+    override static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
+}

--- a/ios/SFPYCardFieldView.swift
+++ b/ios/SFPYCardFieldView.swift
@@ -1,0 +1,107 @@
+import Foundation
+import React
+import SafepayiOSSDK
+import UIKit
+
+@objc(SFPYCardFieldView)
+class SFPYCardFieldView: UIView {
+    @objc var onCardChange: RCTDirectEventBlock?
+    @objc var onFocusChange: RCTDirectEventBlock?
+    @objc var dangerouslyGetFullCardDetails: Bool = false {
+        didSet {
+            cardFieldView.dangerouslyGetFullCardDetails = dangerouslyGetFullCardDetails
+        }
+    }
+    @objc var disabled: Bool = false {
+        didSet {
+            cardFieldView.isUserInteractionEnabled = !disabled
+        }
+    }
+    @objc var autofocus: Bool = false {
+        didSet {
+            if autofocus {
+                cardFieldView.focus()
+            }
+        }
+    }
+
+    private let cardFieldView = SafepayCardFieldView()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupView()
+    }
+
+    @objc func focus() {
+        cardFieldView.focus()
+    }
+
+    @objc func blur() {
+        cardFieldView.blur()
+    }
+
+    @objc func clear() {
+        cardFieldView.clear()
+    }
+
+    private func setupView() {
+        cardFieldView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(cardFieldView)
+
+        NSLayoutConstraint.activate([
+            cardFieldView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            cardFieldView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            cardFieldView.topAnchor.constraint(equalTo: topAnchor),
+            cardFieldView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+
+        cardFieldView.cardChangeHandler = { [weak self] details in
+            self?.emitCardChange(details)
+        }
+        cardFieldView.focusChangeHandler = { [weak self] focus in
+            self?.emitFocusChange(focus)
+        }
+    }
+
+    private func emitCardChange(_ details: SafepayCardFieldDetails) {
+        var card: [String: Any] = [
+            "complete": details.complete,
+            "validNumber": details.validNumber,
+            "validCVC": details.validCVC,
+            "validExpiryDate": details.validExpiryDate,
+        ]
+
+        card["brand"] = details.brand ?? NSNull()
+        card["last4"] = details.last4 ?? ""
+
+        if let expiryMonth = details.expiryMonth {
+            card["expiryMonth"] = expiryMonth
+        } else {
+            card["expiryMonth"] = NSNull()
+        }
+
+        if let expiryYear = details.expiryYear {
+            card["expiryYear"] = expiryYear
+        } else {
+            card["expiryYear"] = NSNull()
+        }
+
+        if let number = details.number {
+            card["number"] = number
+        }
+        if let cvc = details.cvc {
+            card["cvc"] = cvc
+        }
+
+        onCardChange?(["card": card])
+    }
+
+    private func emitFocusChange(_ focus: SafepayCardFieldFocusField?) {
+        onFocusChange?(["focusedField": focus?.rawValue ?? ""])
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sfpy/react-native",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sfpy/react-native",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@sfpy/node-core": "^0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sfpy/react-native",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sfpy/react-native",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@sfpy/node-core": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@sfpy/react-native",
   "author": "Safepay",
   "description": "Official React Native SDK to perform Payer Authentication and Device Data Collection",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "license": "MIT",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@sfpy/react-native",
   "author": "Safepay",
   "description": "Official React Native SDK to perform Payer Authentication and Device Data Collection",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": false,
   "license": "MIT",
   "main": "dist/index.js",

--- a/sfpy-react-native.podspec
+++ b/sfpy-react-native.podspec
@@ -1,0 +1,21 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = 'sfpy-react-native'
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+  s.author       = package['author']
+  s.homepage     = 'https://github.com/safepay/sfpy-react-native'
+  s.platforms    = { :ios => '15.1' }
+  s.source       = { :path => '.' }
+
+  s.source_files = 'ios/**/*.{h,m,mm,swift}'
+  s.requires_arc = true
+  s.swift_version = '5.0'
+
+  s.dependency 'React-Core'
+  s.dependency 'SafepayiOSSDK'
+end

--- a/src/components/CardCapture.tsx
+++ b/src/components/CardCapture.tsx
@@ -1,0 +1,79 @@
+import React, { useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import { CardField } from './CardField';
+import type { CardFieldDetails, CardFieldMethods } from '../types';
+
+export type CardCaptureMethods = {
+  submit(): void;
+  validate(): boolean;
+  fetchValidity(): Promise<boolean>;
+  clear(): void;
+};
+
+export interface CardCaptureProps {
+  environment: string;
+  authToken: string;
+  tracker: string;
+  validationEvent?: string;
+  onValidated?(): void;
+  onError?(error: string): void;
+  onReady?(): void;
+  onCardChange?(card: CardFieldDetails): void;
+  imperativeRef: React.MutableRefObject<CardCaptureMethods | null>;
+}
+
+export const CardCapture: React.FC<CardCaptureProps> = ({
+  environment,
+  authToken,
+  tracker,
+  validationEvent,
+  onValidated,
+  onError,
+  onReady,
+  onCardChange,
+  imperativeRef,
+}) => {
+  void environment;
+  void authToken;
+  void tracker;
+  void validationEvent;
+
+  const cardFieldRef = useRef<CardFieldMethods>(null);
+  const [cardDetails, setCardDetails] = useState<CardFieldDetails | null>(null);
+
+  useEffect(() => {
+    onReady?.();
+  }, [onReady]);
+
+  const validate = useCallback(() => {
+    return Boolean(cardDetails?.complete);
+  }, [cardDetails]);
+
+  const submit = useCallback(() => {
+    if (validate()) {
+      onValidated?.();
+    } else {
+      onError?.('Card details are incomplete.');
+    }
+  }, [validate, onValidated, onError]);
+
+  useImperativeHandle(
+    imperativeRef,
+    () => ({
+      submit,
+      validate,
+      fetchValidity: async () => validate(),
+      clear: () => cardFieldRef.current?.clear(),
+    }),
+    [submit, validate]
+  );
+
+  const handleCardChange = useCallback(
+    (card: CardFieldDetails) => {
+      setCardDetails(card);
+      onCardChange?.(card);
+    },
+    [onCardChange]
+  );
+
+  return <CardField ref={cardFieldRef} onCardChange={handleCardChange} />;
+};

--- a/src/components/CardCapture.tsx
+++ b/src/components/CardCapture.tsx
@@ -1,6 +1,18 @@
-import React, { useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
-import { CardField } from './CardField';
-import type { CardFieldDetails, CardFieldMethods } from '../types';
+import React, { useCallback, useImperativeHandle, useRef, useState } from 'react';
+import {
+  NativeSyntheticEvent,
+  ViewProps,
+  StyleProp,
+  ViewStyle,
+  UIManager,
+  findNodeHandle,
+  requireNativeComponent,
+} from 'react-native';
+import type {
+  CardCaptureError,
+  CardCaptureProceedToAuthenticationData,
+  CardFieldDetails,
+} from '../types';
 
 export type CardCaptureMethods = {
   submit(): void;
@@ -9,17 +21,60 @@ export type CardCaptureMethods = {
   clear(): void;
 };
 
-export interface CardCaptureProps {
+export interface CardCaptureProps extends ViewProps {
+  style?: StyleProp<ViewStyle>;
   environment: string;
   authToken: string;
   tracker: string;
   validationEvent?: string;
   onValidated?(): void;
-  onError?(error: string): void;
+  onError?(error: CardCaptureError): void;
   onReady?(): void;
   onCardChange?(card: CardFieldDetails): void;
+  onProceedToAuthentication?(data: CardCaptureProceedToAuthenticationData): void;
   imperativeRef: React.MutableRefObject<CardCaptureMethods | null>;
+  disabled?: boolean;
+  autofocus?: boolean;
 }
+
+type NativeCardChangeEvent = {
+  card: CardFieldDetails;
+};
+
+type NativeErrorEvent = {
+  error: CardCaptureError;
+};
+
+type NativeProceedEvent = {
+  result: CardCaptureProceedToAuthenticationData;
+};
+
+type NativeProps = ViewProps & {
+  environment: string;
+  authToken: string;
+  tracker: string;
+  disabled?: boolean;
+  autofocus?: boolean;
+  onReady?: (event: NativeSyntheticEvent<Record<string, never>>) => void;
+  onCardChange?: (event: NativeSyntheticEvent<NativeCardChangeEvent>) => void;
+  onValidated?: (event: NativeSyntheticEvent<Record<string, never>>) => void;
+  onError?: (event: NativeSyntheticEvent<NativeErrorEvent>) => void;
+  onProceedToAuthentication?: (
+    event: NativeSyntheticEvent<NativeProceedEvent>
+  ) => void;
+};
+
+const COMPONENT_NAME = 'SFPYCardCapture';
+const NativeCardCapture = requireNativeComponent<NativeProps>(COMPONENT_NAME);
+
+const dispatchCommand = (viewRef: React.Component<any> | null, command: string) => {
+  const node = viewRef ? findNodeHandle(viewRef) : null;
+  if (!node) return;
+  const config = UIManager.getViewManagerConfig(COMPONENT_NAME);
+  const commandId = config?.Commands?.[command];
+  if (commandId == null) return;
+  UIManager.dispatchViewManagerCommand(node, commandId, []);
+};
 
 export const CardCapture: React.FC<CardCaptureProps> = ({
   environment,
@@ -30,31 +85,30 @@ export const CardCapture: React.FC<CardCaptureProps> = ({
   onError,
   onReady,
   onCardChange,
+  onProceedToAuthentication,
   imperativeRef,
+  disabled,
+  autofocus,
+  ...props
 }) => {
-  void environment;
-  void authToken;
-  void tracker;
   void validationEvent;
 
-  const cardFieldRef = useRef<CardFieldMethods>(null);
+  const nativeRef = useRef<any>(null);
   const [cardDetails, setCardDetails] = useState<CardFieldDetails | null>(null);
 
-  useEffect(() => {
-    onReady?.();
-  }, [onReady]);
-
-  const validate = useCallback(() => {
-    return Boolean(cardDetails?.complete);
-  }, [cardDetails]);
+  const validate = useCallback(() => Boolean(cardDetails?.complete), [cardDetails]);
 
   const submit = useCallback(() => {
-    if (validate()) {
-      onValidated?.();
-    } else {
-      onError?.('Card details are incomplete.');
+    if (!validate()) {
+      onError?.({
+        code: 'PT-1002',
+        message: 'Card details are incomplete or invalid. Please check the entered card details and try again.',
+      });
+      return;
     }
-  }, [validate, onValidated, onError]);
+
+    dispatchCommand(nativeRef.current, 'submit');
+  }, [onError, validate]);
 
   useImperativeHandle(
     imperativeRef,
@@ -62,18 +116,59 @@ export const CardCapture: React.FC<CardCaptureProps> = ({
       submit,
       validate,
       fetchValidity: async () => validate(),
-      clear: () => cardFieldRef.current?.clear(),
+      clear: () => {
+        setCardDetails(null);
+        dispatchCommand(nativeRef.current, 'clear');
+      },
     }),
     [submit, validate]
   );
 
-  const handleCardChange = useCallback(
-    (card: CardFieldDetails) => {
+  const onCardChangeHandler = useCallback(
+    (event: NativeSyntheticEvent<NativeCardChangeEvent>) => {
+      const card = event.nativeEvent.card;
       setCardDetails(card);
       onCardChange?.(card);
     },
     [onCardChange]
   );
 
-  return <CardField ref={cardFieldRef} onCardChange={handleCardChange} />;
+  const onReadyHandler = useCallback(() => {
+    onReady?.();
+  }, [onReady]);
+
+  const onValidatedHandler = useCallback(() => {
+    onValidated?.();
+  }, [onValidated]);
+
+  const onErrorHandler = useCallback(
+    (event: NativeSyntheticEvent<NativeErrorEvent>) => {
+      onError?.(event.nativeEvent.error);
+    },
+    [onError]
+  );
+
+  const onProceedHandler = useCallback(
+    (event: NativeSyntheticEvent<NativeProceedEvent>) => {
+      onProceedToAuthentication?.(event.nativeEvent.result);
+    },
+    [onProceedToAuthentication]
+  );
+
+  return (
+    <NativeCardCapture
+      ref={nativeRef}
+      environment={environment}
+      authToken={authToken}
+      tracker={tracker}
+      disabled={disabled ?? false}
+      autofocus={autofocus ?? false}
+      onReady={onReadyHandler}
+      onCardChange={onCardChangeHandler}
+      onValidated={onValidatedHandler}
+      onError={onErrorHandler}
+      onProceedToAuthentication={onProceedHandler}
+      {...props}
+    />
+  );
 };

--- a/src/components/CardField.tsx
+++ b/src/components/CardField.tsx
@@ -1,0 +1,112 @@
+import React, {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useRef,
+} from 'react';
+import {
+  NativeSyntheticEvent,
+  requireNativeComponent,
+  UIManager,
+  findNodeHandle,
+  ViewProps,
+  StyleProp,
+  ViewStyle,
+} from 'react-native';
+import type {
+  CardFieldDetails,
+  CardFieldFocusField,
+  CardFieldMethods,
+} from '../types';
+
+type NativeCardChangeEvent = {
+  card: CardFieldDetails;
+};
+
+type NativeFocusChangeEvent = {
+  focusedField: string;
+};
+
+export interface CardFieldProps extends ViewProps {
+  style?: StyleProp<ViewStyle>;
+  autofocus?: boolean;
+  disabled?: boolean;
+  dangerouslyGetFullCardDetails?: boolean;
+  onCardChange?(card: CardFieldDetails): void;
+  onFocus?(focusedField: CardFieldFocusField): void;
+  onBlur?(): void;
+}
+
+type NativeProps = ViewProps & {
+  autofocus?: boolean;
+  disabled?: boolean;
+  dangerouslyGetFullCardDetails?: boolean;
+  onCardChange?: (event: NativeSyntheticEvent<NativeCardChangeEvent>) => void;
+  onFocusChange?: (event: NativeSyntheticEvent<NativeFocusChangeEvent>) => void;
+};
+
+const COMPONENT_NAME = 'SFPYCardField';
+const NativeCardField = requireNativeComponent<NativeProps>(COMPONENT_NAME);
+
+const dispatchCommand = (viewRef: React.Component<any> | null, command: string) => {
+  const node = viewRef ? findNodeHandle(viewRef) : null;
+  if (!node) return;
+  const config = UIManager.getViewManagerConfig(COMPONENT_NAME);
+  const commandId = config?.Commands?.[command];
+  if (commandId == null) return;
+  UIManager.dispatchViewManagerCommand(node, commandId, []);
+};
+
+export const CardField = forwardRef<CardFieldMethods, CardFieldProps>(
+  (
+    {
+      onCardChange,
+      onFocus,
+      onBlur,
+      autofocus,
+      disabled,
+      dangerouslyGetFullCardDetails,
+      ...props
+    },
+    ref
+  ) => {
+    const nativeRef = useRef<any>(null);
+
+    const onCardChangeHandler = useCallback(
+      (event: NativeSyntheticEvent<NativeCardChangeEvent>) => {
+        onCardChange?.(event.nativeEvent.card);
+      },
+      [onCardChange]
+    );
+
+    const onFocusChangeHandler = useCallback(
+      (event: NativeSyntheticEvent<NativeFocusChangeEvent>) => {
+        const focusedField = event.nativeEvent.focusedField;
+        if (focusedField) {
+          onFocus?.(focusedField as CardFieldFocusField);
+        } else {
+          onBlur?.();
+        }
+      },
+      [onFocus, onBlur]
+    );
+
+    useImperativeHandle(ref, () => ({
+      focus: () => dispatchCommand(nativeRef.current, 'focus'),
+      blur: () => dispatchCommand(nativeRef.current, 'blur'),
+      clear: () => dispatchCommand(nativeRef.current, 'clear'),
+    }));
+
+    return (
+      <NativeCardField
+        ref={nativeRef}
+        onCardChange={onCardChangeHandler}
+        onFocusChange={onFocusChangeHandler}
+        autofocus={autofocus ?? false}
+        disabled={disabled ?? false}
+        dangerouslyGetFullCardDetails={dangerouslyGetFullCardDetails ?? false}
+        {...props}
+      />
+    );
+  }
+);

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,3 @@
 export * from './SafepayPayerAuthentication';
+export * from './CardField';
+export * from './CardCapture';

--- a/src/types/card/CardField.ts
+++ b/src/types/card/CardField.ts
@@ -24,3 +24,25 @@ export type CardFieldMethods = {
   blur(): void;
   clear(): void;
 };
+
+export type CardCapturePaymentMethod = {
+  token: string;
+  expirationMonth: string;
+  expirationYear: string;
+  cardTypeCode: string;
+  cardType: string;
+  binNumber: string;
+  lastFour: string;
+};
+
+export type CardCaptureProceedToAuthenticationData = {
+  accessToken: string;
+  deviceDataCollectionURL: string;
+  cardinalJWT?: string | null;
+  paymentMethod: CardCapturePaymentMethod;
+};
+
+export type CardCaptureError = {
+  code?: string | null;
+  message: string;
+};

--- a/src/types/card/CardField.ts
+++ b/src/types/card/CardField.ts
@@ -1,0 +1,26 @@
+export type CardFieldValidationState =
+  | 'Valid'
+  | 'Invalid'
+  | 'Incomplete'
+  | 'Unknown';
+
+export type CardFieldDetails = {
+  last4?: string;
+  expiryMonth?: number | null;
+  expiryYear?: number | null;
+  complete: boolean;
+  brand?: string | null;
+  validExpiryDate?: CardFieldValidationState;
+  validNumber?: CardFieldValidationState;
+  validCVC?: CardFieldValidationState;
+  number?: string;
+  cvc?: string;
+};
+
+export type CardFieldFocusField = 'CardNumber' | 'ExpiryDate' | 'Cvc';
+
+export type CardFieldMethods = {
+  focus(): void;
+  blur(): void;
+  clear(): void;
+};

--- a/src/types/card/index.ts
+++ b/src/types/card/index.ts
@@ -1,0 +1,1 @@
+export * from './CardField';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from './general';
 export * from './order';
 export * from './payments';
+export * from './card';


### PR DESCRIPTION
## Summary
- Add iOS/Android native view managers for SFPYCardField
- Add CardField and CardCapture components + types
- Add iOS podspec for native bridging
- Bump package version to 0.2.0

## Depends on
- iOS SDK: https://github.com/getsafepay/safepay-ios-sdk/pull/1
- Android SDK: https://github.com/getsafepay/safepay-android-sdk/pull/1

## Required by
- Example app: https://github.com/getsafepay/safepay-react-native-sdk-example/pull/2

## Related PRs
- iOS SDK: https://github.com/getsafepay/safepay-ios-sdk/pull/1
- Android SDK: https://github.com/getsafepay/safepay-android-sdk/pull/1
- Example app: https://github.com/getsafepay/safepay-react-native-sdk-example/pull/2