### PR TITLE
fix: harden payer auth bridge origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ export default function Index() {
         <SafepayContext.Provider value={values}>
             <SafepayPayerAuthentication
                 environment={ENVIRONMENT.DEVELOPMENT}
+                onPayerAuthenticationSuccess={(data) => console.log("onPayerAuthenticationSuccess", data)}
+                onPayerAuthenticationFailure={(data) => console.log("onPayerAuthenticationFailure", data)}
+                onPayerAuthenticationRequired={(data) => console.log("onPayerAuthenticationRequired", data)}
+                onPayerAuthenticationFrictionless={(data) => console.log("onPayerAuthenticationFrictionless", data)}
+                onPayerAuthenticationUnavailable={(data) => console.log("onPayerAuthenticationUnavailable", data)}
                 onCardinalSuccess={(data: Cardinal3dsSuccessData) => console.log("onCardinalSuccess", data)}
                 onCardinalError={(error: Cardinal3dsFailureData) => console.log("onCardinalError", error)}
                 onPayerAuthEnrollmentRequired={() => console.log("onPayerAuthEnrollmentRequired")}
@@ -62,11 +67,55 @@ export default function Index() {
 };
 ```
 
+### SafepayPayerAuthentication Props
+
+| Property | Type | Description |
+|---|---|---|
+| environment | `'development' \| 'production' \| 'sandbox' \| 'local'` | Environment setting |
+| doCaptureOnAuthorization | boolean | Enables capture during authorization |
+| doCardOnFile | boolean | Enables card-on-file during authorization |
+| onPayerAuthenticationSuccess | function | Atoms-compatible callback for successful 3DS completion |
+| onPayerAuthenticationFailure | function | Atoms-compatible callback for failed 3DS completion |
+| onPayerAuthenticationRequired | function | Atoms-compatible callback for enrollment-required events |
+| onPayerAuthenticationFrictionless | function | Atoms-compatible callback for frictionless enrollment events |
+| onPayerAuthenticationUnavailable | function | Atoms-compatible callback for unavailable enrollment events |
+| onSafepayError | function | Callback for Safepay iframe errors |
+| onCardinalSuccess | function | Deprecated alias for `onPayerAuthenticationSuccess` |
+| onCardinalError | function | Deprecated alias for `onPayerAuthenticationFailure` |
+| onPayerAuthEnrollmentRequired | function | Deprecated alias for `onPayerAuthenticationRequired` |
+| onPayerAuthEnrollmentFrictionless | function | Deprecated alias for `onPayerAuthenticationFrictionless` |
+| onPayerAuthEnrollmentUnavailable | function | Deprecated alias for `onPayerAuthenticationUnavailable` |
+| onPayerAuthEnrollmentFailure | function | Deprecated alias for `onPayerAuthenticationUnavailable` |
+
 ### SafepayPayerAuthentication Callbacks
 
-The component accepts several callbacks that receive response payloads. Below are example responses:
+The component accepts atoms-compatible callbacks and keeps the older React Native callback names for backward compatibility.
 
-#### onCardinalSuccess
+#### Atoms-compatible callbacks
+
+| Callback | Payload | Description |
+|---|---|---|
+| onPayerAuthenticationSuccess | `{ tracker, request_id, payment_method?, authorization? }` | Fired when Cardinal 3DS succeeds |
+| onPayerAuthenticationFailure | `{ tracker, request_id, error }` | Fired when Cardinal 3DS fails |
+| onPayerAuthenticationRequired | `{ tracker, request_id? }` | Fired when payer authentication enrollment is required |
+| onPayerAuthenticationFrictionless | `{ tracker, request_id? }` | Fired when payer authentication completes frictionlessly |
+| onPayerAuthenticationUnavailable | `{ tracker, request_id? }` | Fired when payer authentication enrollment is unavailable |
+| onSafepayError | `{ error: SafepayError }` | Fired when Safepay returns an iframe-level error |
+
+#### Deprecated callbacks
+
+| Callback | Status | Notes |
+|---|---|---|
+| onCardinalSuccess | Deprecated | Use `onPayerAuthenticationSuccess` |
+| onCardinalError | Deprecated | Use `onPayerAuthenticationFailure` |
+| onPayerAuthEnrollmentRequired | Deprecated | Use `onPayerAuthenticationRequired` |
+| onPayerAuthEnrollmentFrictionless | Deprecated | Use `onPayerAuthenticationFrictionless` |
+| onPayerAuthEnrollmentUnavailable | Deprecated | Use `onPayerAuthenticationUnavailable` |
+| onPayerAuthEnrollmentFailure | Deprecated | Use `onPayerAuthenticationUnavailable` |
+
+Below are example responses:
+
+#### onPayerAuthenticationSuccess / onCardinalSuccess
 Called when Cardinal 3DS authentication succeeds. Example response:
 
 ```json
@@ -81,7 +130,7 @@ Called when Cardinal 3DS authentication succeeds. Example response:
 }
 ```
 
-#### onCardinalError
+#### onPayerAuthenticationFailure / onCardinalError
 Called when Cardinal 3DS authentication fails. Example response:
 
 ```json
@@ -96,10 +145,18 @@ Called when Cardinal 3DS authentication fails. Example response:
 }
 ```
 
-#### onPayerAuthEnrollmentRequired
-Called when payer authentication enrollment is required but receives no response data.
+#### onPayerAuthenticationRequired / onPayerAuthEnrollmentRequired
+Called when payer authentication enrollment is required. The new callback receives normalized payload data; the deprecated callback still fires without arguments for backward compatibility.
 
-#### onPayerAuthEnrollmentFrictionless
+Atoms-compatible payload:
+
+```json
+{
+  "tracker": "track_a098c800-a24b-4eb2-ab62-aa8967a099df"
+}
+```
+
+#### onPayerAuthenticationFrictionless / onPayerAuthEnrollmentFrictionless
 Called when payer authentication enrollment is completed with frictionless authentication. Example response:
 
 ```json
@@ -113,8 +170,18 @@ Called when payer authentication enrollment is completed with frictionless authe
 }
 ```
 
-#### onPayerAuthEnrollmentUnavailable
-Called when payer authentication enrollment fails/unavailable. Example response:
+#### onPayerAuthenticationUnavailable / onPayerAuthEnrollmentUnavailable
+Called when payer authentication enrollment fails/unavailable.
+
+Atoms-compatible payload:
+
+```json
+{
+  "tracker": "track_c6ead7f5-681c-469e-ab9f-4f2cc1f144e8"
+}
+```
+
+Deprecated callback payload:
 
 ```json
 {

--- a/docs/actions/01-harden-payer-auth-bridge-origin.md
+++ b/docs/actions/01-harden-payer-auth-bridge-origin.md
@@ -1,0 +1,20 @@
+# 01 Harden Payer Auth Bridge Origin
+
+Status: implemented.
+
+## What changed
+Updated `src/components/SafepayPayerAuthentication/index.tsx` so the React Native WebView bridge now matches the hardened Drops `postMessage` contract.
+
+The component now:
+- derives the exact Drops origin from the selected environment base URL
+- loads Drops `/authlink` with an explicit `parentOrigin` query parameter
+- posts bridge messages into the WebView with that exact origin instead of `"*"`
+
+## Why this was necessary
+Recent Drops changes stopped accepting wildcard or implicit bridge origins. The Drops message manager now expects a trusted parent origin and rejects bridge traffic that does not match it exactly.
+
+`sfpy-react-native` was still:
+- loading `/authlink` without a `parentOrigin`
+- injecting `window.postMessage(..., "*")`
+
+That left the React Native payer-auth flow out of contract with Drops hardening, especially around 3DS success and failure callbacks.

--- a/docs/actions/02-align-payer-auth-callbacks.md
+++ b/docs/actions/02-align-payer-auth-callbacks.md
@@ -1,0 +1,33 @@
+# 02 Align Payer Auth Callbacks
+
+I aligned `SafepayPayerAuthentication` with the callback names used in `safepay-atoms` while keeping the older React Native callback names in place as deprecated aliases.
+
+## Implemented changes
+
+- Added atoms-compatible callbacks:
+  - `onPayerAuthenticationSuccess`
+  - `onPayerAuthenticationFailure`
+  - `onPayerAuthenticationRequired`
+  - `onPayerAuthenticationFrictionless`
+  - `onPayerAuthenticationUnavailable`
+- Kept the existing callbacks and marked them as deprecated:
+  - `onCardinalSuccess`
+  - `onCardinalError`
+  - `onPayerAuthEnrollmentRequired`
+  - `onPayerAuthEnrollmentFrictionless`
+  - `onPayerAuthEnrollmentFailure`
+  - `onPayerAuthEnrollmentUnavailable`
+- Added exported payer-auth callback payload types that mirror the atoms contract:
+  - `PayerAuthenticationData`
+  - `PayerAuthenticationErrorData`
+  - `PayerAuthenticationSuccessData`
+- Updated the event mapping so each payer-auth event now emits both:
+  - the new atoms-compatible callback
+  - the existing deprecated React Native callback
+
+## Payload handling
+
+- `required`, `frictionless`, and `unavailable` now emit a normalized `{ tracker, request_id }` payload for the new callbacks.
+- `failure` now emits `{ tracker, request_id, error }` for the new callback.
+- `success` now emits `{ tracker, request_id, payment_method, authorization? }` for the new callback.
+- The deprecated callbacks still receive the same legacy payloads as before.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sfpy/react-native",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sfpy/react-native",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@sfpy/node-core": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@sfpy/react-native",
   "author": "Safepay",
   "description": "Official React Native SDK to perform Payer Authentication and Device Data Collection",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "license": "MIT",
   "main": "dist/index.js",

--- a/src/components/SafepayPayerAuthentication/index.tsx
+++ b/src/components/SafepayPayerAuthentication/index.tsx
@@ -17,6 +17,9 @@ import {
   Cardinal3dsFailureData,
   Cardinal3dsSuccessData,
   OnSafepayErrorData,
+  PayerAuthenticationData,
+  PayerAuthenticationErrorData,
+  PayerAuthenticationSuccessData,
   PayerAuthEnrollmentFailureError,
   PayerAuthEnrollmentUnavailableError,
   PendingMessage,
@@ -24,16 +27,36 @@ import {
 
 export type SafepayPayerAuthenticationProps = {
   onSafepayError?: (data: OnSafepayErrorData) => void;
+  onPayerAuthenticationSuccess?: (data: PayerAuthenticationSuccessData) => void;
+  onPayerAuthenticationFailure?: (data: PayerAuthenticationErrorData) => void;
+  onPayerAuthenticationRequired?: (data: PayerAuthenticationData) => void;
+  onPayerAuthenticationFrictionless?: (data: PayerAuthenticationData) => void;
+  onPayerAuthenticationUnavailable?: (data: PayerAuthenticationData) => void;
+  /**
+   * @deprecated Use `onPayerAuthenticationSuccess` instead.
+   */
   onCardinalSuccess?: (data: Cardinal3dsSuccessData) => void;
+  /**
+   * @deprecated Use `onPayerAuthenticationFailure` instead.
+   */
   onCardinalError?: (data: Cardinal3dsFailureData) => void;
+  /**
+   * @deprecated Use `onPayerAuthenticationRequired` instead.
+   */
   onPayerAuthEnrollmentRequired?: () => void;
+  /**
+   * @deprecated Use `onPayerAuthenticationFrictionless` instead.
+   */
   onPayerAuthEnrollmentFrictionless?: (data: AuthorizationResponse) => void;
   /**
-   * @deprecated Use `onPayerAuthEnrollmentUnavailable` instead.
+   * @deprecated Use `onPayerAuthenticationUnavailable` instead.
    */
   onPayerAuthEnrollmentFailure?: (
     error: PayerAuthEnrollmentFailureError,
   ) => void;
+  /**
+   * @deprecated Use `onPayerAuthenticationUnavailable` instead.
+   */
   onPayerAuthEnrollmentUnavailable?: (
     error: PayerAuthEnrollmentUnavailableError,
   ) => void;
@@ -44,6 +67,11 @@ export type SafepayPayerAuthenticationProps = {
 
 export const SafepayPayerAuthentication = ({
   onSafepayError,
+  onPayerAuthenticationSuccess,
+  onPayerAuthenticationFailure,
+  onPayerAuthenticationRequired,
+  onPayerAuthenticationFrictionless,
+  onPayerAuthenticationUnavailable,
   onCardinalSuccess,
   onCardinalError,
   onPayerAuthEnrollmentRequired,
@@ -225,6 +253,33 @@ export const SafepayPayerAuthentication = ({
     [],
   );
 
+  const buildPayerAuthenticationData = useCallback(
+    (data: Partial<PayerAuthenticationData>): PayerAuthenticationData => ({
+      tracker: data.tracker || tracker,
+      request_id: data.request_id,
+    }),
+    [tracker],
+  );
+
+  const buildPayerAuthenticationErrorData = useCallback(
+    (data: Partial<PayerAuthenticationErrorData>): PayerAuthenticationErrorData => ({
+      ...buildPayerAuthenticationData(data),
+      error: data.error || 'Unknown payer authentication error',
+    }),
+    [buildPayerAuthenticationData],
+  );
+
+  const buildPayerAuthenticationSuccessData = useCallback(
+    (
+      data: Partial<PayerAuthenticationSuccessData>,
+    ): PayerAuthenticationSuccessData => ({
+      ...buildPayerAuthenticationData(data),
+      authorization: data.authorization,
+      payment_method: data.payment_method,
+    }),
+    [buildPayerAuthenticationData],
+  );
+
   const onMessage = useCallback(
     (event: WebViewMessageEvent) => {
       try {
@@ -252,21 +307,50 @@ export const SafepayPayerAuthentication = ({
             }
             break;
           }
-          case 'safepay-inframe__cardinal-3ds__success':
+          case 'safepay-inframe__cardinal-3ds__success': {
+            const successData = buildPayerAuthenticationSuccessData(
+              data as PayerAuthenticationSuccessData,
+            );
+            onPayerAuthenticationSuccess &&
+              onPayerAuthenticationSuccess(successData);
             onCardinalSuccess &&
               onCardinalSuccess(data as Cardinal3dsSuccessData);
             break;
-          case 'safepay-inframe__cardinal-3ds__failure':
+          }
+          case 'safepay-inframe__cardinal-3ds__failure': {
+            const failureData = buildPayerAuthenticationErrorData(
+              data as PayerAuthenticationErrorData,
+            );
+            onPayerAuthenticationFailure &&
+              onPayerAuthenticationFailure(failureData);
             onCardinalError && onCardinalError(data as Cardinal3dsFailureData);
             break;
-          case 'safepay-inframe__enrollment__required':
+          }
+          case 'safepay-inframe__enrollment__required': {
+            const requiredData = buildPayerAuthenticationData(
+              data as PayerAuthenticationData,
+            );
+            onPayerAuthenticationRequired &&
+              onPayerAuthenticationRequired(requiredData);
             onPayerAuthEnrollmentRequired && onPayerAuthEnrollmentRequired();
             break;
-          case 'safepay-inframe__enrollment__frictionless':
+          }
+          case 'safepay-inframe__enrollment__frictionless': {
+            const frictionlessData = buildPayerAuthenticationData(
+              data as PayerAuthenticationData,
+            );
+            onPayerAuthenticationFrictionless &&
+              onPayerAuthenticationFrictionless(frictionlessData);
             onPayerAuthEnrollmentFrictionless &&
               onPayerAuthEnrollmentFrictionless(data as AuthorizationResponse);
             break;
-          case 'safepay-inframe__enrollment__failed':
+          }
+          case 'safepay-inframe__enrollment__failed': {
+            const unavailableData = buildPayerAuthenticationData(
+              data as PayerAuthenticationData,
+            );
+            onPayerAuthenticationUnavailable &&
+              onPayerAuthenticationUnavailable(unavailableData);
             if (onPayerAuthEnrollmentUnavailable) {
               onPayerAuthEnrollmentUnavailable(
                 data as PayerAuthEnrollmentUnavailableError,
@@ -278,6 +362,7 @@ export const SafepayPayerAuthentication = ({
               );
             }
             break;
+          }
           case 'safepay-error':
             onSafepayError && onSafepayError(data as OnSafepayErrorData);
             break;
@@ -286,7 +371,23 @@ export const SafepayPayerAuthentication = ({
         console.log(e);
       }
     },
-    [onCardinalSuccess, onCardinalError, onSafepayError],
+    [
+      buildPayerAuthenticationData,
+      buildPayerAuthenticationErrorData,
+      buildPayerAuthenticationSuccessData,
+      onCardinalError,
+      onCardinalSuccess,
+      onPayerAuthenticationFailure,
+      onPayerAuthenticationFrictionless,
+      onPayerAuthenticationRequired,
+      onPayerAuthenticationSuccess,
+      onPayerAuthenticationUnavailable,
+      onPayerAuthEnrollmentFailure,
+      onPayerAuthEnrollmentFrictionless,
+      onPayerAuthEnrollmentRequired,
+      onPayerAuthEnrollmentUnavailable,
+      onSafepayError,
+    ],
   );
 
   return (

--- a/src/components/SafepayPayerAuthentication/index.tsx
+++ b/src/components/SafepayPayerAuthentication/index.tsx
@@ -75,7 +75,10 @@ export const SafepayPayerAuthentication = ({
   };
 
   const baseUrl = getBaseUrl();
-  const deviceUrl = `${baseUrl}/authlink`;
+  const bridgeOrigin = new URL(baseUrl).origin;
+  const deviceUrl = `${baseUrl}/authlink?parentOrigin=${encodeURIComponent(
+    bridgeOrigin,
+  )}`;
 
   const webViewRef = useRef<WebView>(null);
   const isReadyRef = useRef(false);
@@ -142,14 +145,14 @@ export const SafepayPayerAuthentication = ({
     if (!webViewRef.current) return;
     const script = `
       if (window.postMessage) {
-        window.postMessage(${JSON.stringify(payload)}, "*");
+        window.postMessage(${JSON.stringify(payload)}, "${bridgeOrigin}");
       } else {
         console.error("postMessage is not supported");
       }
       true;
     `;
     webViewRef.current.injectJavaScript(script);
-  }, []);
+  }, [bridgeOrigin]);
 
   const dispatchMessage = useCallback(
     (entry: PendingMessage) => {

--- a/src/types/payments/PayerAuthenticationData.ts
+++ b/src/types/payments/PayerAuthenticationData.ts
@@ -1,0 +1,13 @@
+export type PayerAuthenticationData = {
+    tracker: string;
+    request_id?: string;
+};
+
+export type PayerAuthenticationErrorData = PayerAuthenticationData & {
+    error: string;
+};
+
+export type PayerAuthenticationSuccessData = PayerAuthenticationData & {
+    authorization?: string;
+    payment_method?: string;
+};

--- a/src/types/payments/index.ts
+++ b/src/types/payments/index.ts
@@ -1,4 +1,5 @@
 export * from './AuthorizationResponse';
 export * from './EnrollmentResponse';
+export * from './PayerAuthenticationData';
 export * from './PayerAuthEnrollmentFailureError';
 export * from './PayerAuthEnrollmentUnavailableError';


### PR DESCRIPTION
## What
- pass an explicit `parentOrigin` to Drops auth routes
- post bridge messages into the WebView using the exact Drops origin instead of `*`
- align `SafepayPayerAuthentication` callbacks with `safepay-atoms`
- keep the existing React Native callback names as deprecated aliases for backward compatibility
- export atoms-compatible payer-auth payload types
- bump `@sfpy/react-native` to `0.1.1`

## Why
Recent postMessage origin hardening in `safepay-drops` requires an exact trusted origin for bridge traffic and 3DS callback messaging. This keeps `sfpy-react-native` aligned with that contract.

The payer-auth callback surface in `sfpy-react-native` had also drifted from `safepay-atoms`. This brings the React Native API back into line without breaking existing consumers.

## Validation
- `npm run build`
- packed `sfpy-react-native-0.1.1.tgz`
- installed the tarball into `safepay-react-native-sdk-example` and verified `node_modules/@sfpy/react-native` reports `0.1.1`
