### PR TITLE
fix: forward errorMessage in onPayerAuthenticationUnavailable callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@sfpy/react-native",
   "author": "Safepay",
   "description": "Official React Native SDK to perform Payer Authentication and Device Data Collection",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": false,
   "license": "MIT",
   "main": "dist/index.js",

--- a/src/components/SafepayPayerAuthentication/index.tsx
+++ b/src/components/SafepayPayerAuthentication/index.tsx
@@ -257,6 +257,7 @@ export const SafepayPayerAuthentication = ({
     (data: Partial<PayerAuthenticationData>): PayerAuthenticationData => ({
       tracker: data.tracker || tracker,
       request_id: data.request_id,
+      errorMessage: data.errorMessage,
     }),
     [tracker],
   );

--- a/src/types/payments/PayerAuthenticationData.ts
+++ b/src/types/payments/PayerAuthenticationData.ts
@@ -1,6 +1,7 @@
 export type PayerAuthenticationData = {
     tracker: string;
     request_id?: string;
+    errorMessage?: string;
 };
 
 export type PayerAuthenticationErrorData = PayerAuthenticationData & {


### PR DESCRIPTION
## Summary

- Adds `errorMessage?: string` to `PayerAuthenticationData` type
- `buildPayerAuthenticationData()` now passes `errorMessage` through from the `safepay-inframe__enrollment__failed` event detail, which drops has always sent but this SDK was silently discarding
- Bumps to `0.1.2`

Without this change, `onPayerAuthenticationUnavailable` only receives `{ tracker, request_id }` — the error message that drops sends is lost.

## Linked PRs

| Repo | PR |
|------|----|
| safepay-drops | getsafepay/safepay-drops#74 |
| safepay-atoms | getsafepay/safepay-atoms#35 |
| android-drops-sdk | getsafepay/android-drops-sdk#1 |
| swift-drops-sdk | getsafepay/swift-drops-sdk#2 |
| android-drops-sdk-example | getsafepay/android-drops-sdk-example#1 |
| swift-drops-sdk-example | getsafepay/swift-drops-sdk-example#1 |
| safepay-react-native-sdk-example | getsafepay/safepay-react-native-sdk-example#3 |